### PR TITLE
fix: restore deleted inventoryDetail.js

### DIFF
--- a/src/api/wms/inventoryDetail.js
+++ b/src/api/wms/inventoryDetail.js
@@ -1,0 +1,53 @@
+import request from '@/utils/request'
+
+// 分页查询库存详情列表
+export function listInventoryDetail(query) {
+  return request({
+    url: '/wms/inventoryDetail/list',
+    method: 'get',
+    params: query
+  })
+}
+
+// 查询库存详情列表
+export function listInventoryDetailNoPage(query) {
+  return request({
+    url: '/wms/inventoryDetail/listNoPage',
+    method: 'get',
+    params: query
+  })
+}
+
+// 查询库存详情详细
+export function getInventoryDetail(id) {
+  return request({
+    url: '/wms/inventoryDetail/' + id,
+    method: 'get'
+  })
+}
+
+// 新增库存详情
+export function addInventoryDetail(data) {
+  return request({
+    url: '/wms/inventoryDetail',
+    method: 'post',
+    data: data
+  })
+}
+
+// 修改库存详情
+export function updateInventoryDetail(data) {
+  return request({
+    url: '/wms/inventoryDetail',
+    method: 'put',
+    data: data
+  })
+}
+
+// 删除库存详情
+export function delInventoryDetail(id) {
+  return request({
+    url: '/wms/inventoryDetail/' + id,
+    method: 'delete'
+  })
+}

--- a/src/views/wms/order/receipt/edit.vue
+++ b/src/views/wms/order/receipt/edit.vue
@@ -75,20 +75,6 @@
       <el-card header="商品明细" class="mt10">
         <div class="receipt-order-content">
           <div class="flex-space-between mb8">
-            <div>
-              <span>一物一码/SN模式：</span>
-              <el-switch
-                :before-change="goSaasTip"
-                class="mr10 ml10"
-                inline-prompt
-                size="large"
-                v-model="mode"
-                :active-value="true"
-                :inactive-value="false"
-                active-text="开启"
-                inactive-text="关闭"
-              />
-            </div>
             <el-popover
               placement="left"
               title="提示"
@@ -427,12 +413,6 @@ const handleDeleteDetail = (row, index) => {
   } else {
     form.value.details.splice(index, 1)
   }
-}
-const goSaasTip = () => {
-  ElMessageBox.alert('一物一码/SN模式请去Saas版本体验！', '系统提示', {
-    confirmButtonText: '确定'
-  })
-  return false
 }
 </script>
 


### PR DESCRIPTION
npm run 时
> [vite:load-fallback] Could not load /home/lunar/ruoyi-wms/frontend/src/api/wms/inventoryDetail (imported by src/views/components/InventoryDetailSelect.vue): ENOENT: no such file or directory, open '/home/lunar/ruoyi-wms/frontend/src/api/wms/inventoryDetail'

应该是删除库区相关代码时候误删了 bfadc20